### PR TITLE
Add write keymaps and cut-paste bindings to mini.files

### DIFF
--- a/plugin/mini.lua
+++ b/plugin/mini.lua
@@ -173,12 +173,15 @@ vim.api.nvim_create_autocmd("User", {
     local buf = args.data.buf_id
     local files = require("mini.files")
 
+    -- <CR>: open the file under the cursor (closing the explorer) or
+    -- expand a directory in a new column. If the cursor is on a freshly
+    -- typed line that doesn't exist on disk yet, synchronize first so
+    -- mini.files creates the entry, then open it.
     vim.keymap.set("n", "<CR>", function()
       local entry = files.get_fs_entry()
       if entry then
         files.go_in({ close_on_file = true })
       else
-        -- Entry doesn't exist yet — sync to create it, then open
         files.synchronize()
         files.go_in({ close_on_file = true })
       end
@@ -209,19 +212,27 @@ vim.api.nvim_create_autocmd("User", {
       end,
     })
 
-    -- Override the global <C-s> for this buffer. The global mapping uses
-    -- <cmd>w<cr> which runs :w in a restricted context where vim.fn.confirm
-    -- returns its default (Yes) without prompting — auto-applying changes.
+    -- <C-s>: synchronize pending filesystem changes with a confirm prompt.
+    -- Overrides the global <C-s> mapping for this buffer because the global
+    -- one uses <cmd>w<cr>, which runs :w in a restricted context where
+    -- vim.fn.confirm returns its default (Yes) without prompting — silently
+    -- auto-applying changes. Feeding <Esc> afterwards exits insert/visual
+    -- mode so the keymap behaves consistently across modes.
     vim.keymap.set({ "n", "i", "x", "s" }, "<C-s>", function()
       files.synchronize()
       local esc = vim.api.nvim_replace_termcodes("<Esc>", true, false, true)
       vim.api.nvim_feedkeys(esc, "n", false)
     end, { buffer = buf, desc = "Synchronize mini.files" })
 
+    -- H: jump the explorer back to the current working directory.
+    -- Useful when nested deep in a tree and you want to start over from
+    -- the project root without closing and reopening the explorer.
     vim.keymap.set("n", "H", function()
       files.open(vim.uv.cwd(), false)
     end, { buffer = buf, desc = "Go to cwd root" })
 
+    -- q / <Esc>: close the explorer, synchronizing first so any pending
+    -- edits are not silently dropped — the confirm prompt still runs.
     local function sync_and_close()
       files.synchronize()
       files.close()

--- a/plugin/mini.lua
+++ b/plugin/mini.lua
@@ -102,6 +102,9 @@ local function directory_content_width(buf_id)
   return found and max_width or nil
 end
 
+---@type string?
+local cut_line = nil
+
 local augroup = vim.api.nvim_create_augroup("mini_files_config", { clear = true })
 
 -- Keep the preview pane width proportional when the terminal is resized
@@ -227,6 +230,37 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "q", sync_and_close, { buffer = buf, desc = "Sync and close" })
     vim.keymap.set("n", "<Esc>", sync_and_close, { buffer = buf, desc = "Sync and close" })
 
+    -- mm: cut the entry under the cursor. Stashes the entire buffer line
+    -- (including the concealed /<path_id>/ prefix) in a module-local
+    -- variable and removes it from the buffer. Preserving the path_id is
+    -- what lets a subsequent paste be recognized by mini.files's diff as
+    -- a move rather than a delete + create.
+    vim.keymap.set("n", "mm", function()
+      local lnum = vim.api.nvim_win_get_cursor(0)[1]
+      local line = vim.api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1]
+      if not line or line == "" then
+        return
+      end
+      cut_line = line
+      vim.api.nvim_buf_set_lines(buf, lnum - 1, lnum, false, {})
+    end, { buffer = buf, desc = "Cut entry (paste with p)" })
+
+    -- p: paste the previously cut entry below the cursor in any mini.files
+    -- buffer. The move is not committed until the user synchronizes
+    -- (:w / <C-s> / q), so this is safe to undo by closing without sync.
+    vim.keymap.set("n", "p", function()
+      if not cut_line then
+        vim.notify("mini.files: nothing to paste", vim.log.levels.WARN)
+        return
+      end
+      local lnum = vim.api.nvim_win_get_cursor(0)[1]
+      vim.api.nvim_buf_set_lines(buf, lnum, lnum, false, { cut_line })
+      cut_line = nil
+    end, { buffer = buf, desc = "Paste cut entry" })
+
+    -- <M-p>: toggle the preview pane on/off. Flipping the config flag
+    -- alone doesn't redraw, so we re-set the current branch to force
+    -- mini.files to rebuild the layout with the new preview setting.
     vim.keymap.set("n", "<M-p>", function()
       files.config.windows.preview = not files.config.windows.preview
       local state = files.get_explorer_state()

--- a/plugin/mini.lua
+++ b/plugin/mini.lua
@@ -181,6 +181,10 @@ vim.api.nvim_create_autocmd("User", {
       end
     end, { buffer = buf, desc = "Open file or expand directory" })
 
+    -- Route :w through BufWriteCmd. mini.files creates scratch buffers
+    -- (buftype=nofile) which would otherwise reject :w with E382.
+    vim.bo[buf].buftype = "acwrite"
+
     -- Intercept :w to trigger synchronize instead of a regular file write —
     -- prompts the user to confirm pending file system changes
     vim.api.nvim_create_autocmd("BufWriteCmd", {
@@ -189,6 +193,27 @@ vim.api.nvim_create_autocmd("User", {
         files.synchronize()
       end,
     })
+
+    -- :q (and therefore :wq, :x) closes the whole explorer, matching
+    -- the q / <Esc> keymap behavior. Scheduled so the original :q
+    -- finishes first, then files.close() cleans up the rest.
+    vim.api.nvim_create_autocmd("QuitPre", {
+      buffer = buf,
+      callback = function()
+        vim.schedule(function()
+          pcall(files.close)
+        end)
+      end,
+    })
+
+    -- Override the global <C-s> for this buffer. The global mapping uses
+    -- <cmd>w<cr> which runs :w in a restricted context where vim.fn.confirm
+    -- returns its default (Yes) without prompting — auto-applying changes.
+    vim.keymap.set({ "n", "i", "x", "s" }, "<C-s>", function()
+      files.synchronize()
+      local esc = vim.api.nvim_replace_termcodes("<Esc>", true, false, true)
+      vim.api.nvim_feedkeys(esc, "n", false)
+    end, { buffer = buf, desc = "Synchronize mini.files" })
 
     vim.keymap.set("n", "H", function()
       files.open(vim.uv.cwd(), false)


### PR DESCRIPTION
Wire :w, <C-s>, and :wq to mini.files' synchronize() so file operations
are applied on save. Adds mm/p cut-paste keymaps for moving entries, and
explanatory comments on each buffer-local keymap.

Key fix: set buftype=acwrite so BufWriteCmd fires — mini.files previously
created nofile buffers that silently rejected :w before BufWriteCmd was
checked (E382). Also adds QuitPre autocmd so :q/:wq close the full
explorer via MiniFiles.close() rather than just the focused window.