### PR TITLE
Add venv-selector for PEP 723 inline script dependency resolution

### DIFF
--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -212,6 +212,10 @@
       "rev": "123a9fb12e7229342f807ec9e6de478b1102b041",
       "src": "https://github.com/folke/ts-comments.nvim"
     },
+    "venv-selector.nvim": {
+      "rev": "bcb2f58533c59b01565285eba49693f00bc460f5",
+      "src": "https://github.com/linux-cultist/venv-selector.nvim"
+    },
     "vim-eunuch": {
       "rev": "e86bb794a1c10a2edac130feb0ea590a00d03f1e",
       "src": "https://github.com/tpope/vim-eunuch"

--- a/plugin/venv-selector.lua
+++ b/plugin/venv-selector.lua
@@ -1,0 +1,70 @@
+-- github.com/linux-cultist/venv-selector.nvim
+-- Auto-activates per-project and per-PEP-723-script uv venvs so Python LSPs can resolve imports.
+vim.pack.add({ "https://github.com/linux-cultist/venv-selector.nvim" }, { load = false })
+
+local loaded = false
+local function ensure_loaded()
+  if loaded then
+    return
+  end
+  loaded = true
+  vim.cmd.packadd("venv-selector.nvim")
+  require("venv-selector").setup({
+    cache = { file = "~/.cache/venv-selector/venvs2.json" },
+    hooks = {},
+    search = {},
+    options = {
+      notify_user_on_venv_activation = true,
+      cached_venv_automatic_activation = true,
+      enable_default_searches = true,
+      enable_cached_venvs = true,
+      activate_venv_in_terminal = true,
+      set_environment_variables = true,
+      override_notify = true,
+      search_timeout = 5,
+      require_lsp_activation = true,
+      picker_filter_type = "substring",
+      selected_venv_marker_color = "#00FF00",
+      selected_venv_marker_icon = "✔",
+      picker_icons = {},
+      picker_columns = { "marker", "search_icon", "search_name", "search_result" },
+      picker = "auto",
+      statusline_func = { nvchad = nil, lualine = nil },
+      picker_options = {
+        snacks = {
+          layout = { preset = "select" },
+        },
+      },
+    },
+  })
+end
+
+-- Lazy-load venv-selector on the first Python buffer and register buffer-local
+-- <LocalLeader>v... keymaps. Scoping to the buffer keeps them out of non-Python
+-- filetypes and ensures which-key only surfaces them where they apply. Fires on
+-- every Python FileType so keymaps are wired to each buffer individually.
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "python",
+  desc = "Load venv-selector and register buffer-local Python venv keymaps",
+  callback = function(ev)
+    ensure_loaded()
+
+    local bufnr = ev.buf
+    local ok, wk = pcall(require, "which-key")
+    if ok then
+      wk.add({
+        { "<LocalLeader>v", group = "venv", buffer = bufnr, icon = { icon = "󰌠", color = "green" } },
+        { "<LocalLeader>vs", "<Cmd>VenvSelect<CR>", buffer = bufnr, desc = "Select Virtualenv" },
+        { "<LocalLeader>vc", "<Cmd>VenvSelectCached<CR>", buffer = bufnr, desc = "Activate Cached Venv" },
+        { "<LocalLeader>vr", "<Cmd>VenvSelect<CR>", buffer = bufnr, desc = "Resync PEP 723 Script Deps" },
+      })
+    else
+      local function map(lhs, rhs, desc)
+        vim.keymap.set("n", lhs, rhs, { buffer = bufnr, silent = true, desc = desc })
+      end
+      map("<LocalLeader>vs", "<Cmd>VenvSelect<CR>", "Select Virtualenv")
+      map("<LocalLeader>vc", "<Cmd>VenvSelectCached<CR>", "Activate Cached Venv")
+      map("<LocalLeader>vr", "<Cmd>VenvSelect<CR>", "Resync PEP 723 Script Deps")
+    end
+  end,
+})


### PR DESCRIPTION
Integrates venv-selector to automatically pick the correct virtual
environment for Python files using PEP 723 inline script dependency
declarations.