### PR TITLE
Fix selene args crashing Lua lint when assigned as a function

### DIFF
--- a/plugin/nvim-lint.lua
+++ b/plugin/nvim-lint.lua
@@ -10,31 +10,40 @@ vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
   callback = function()
     vim.cmd.packadd("nvim-lint")
     local lint = require("lint")
-    -- Use tests/selene.toml for test files (has busted/luassert globals)
-    lint.linters.selene.args = function()
+
+    lint.linters_by_ft = {
+      lua = { "selene" },
+      markdown = { "markdownlint-cli2" },
+      sh = { "shellcheck" },
+    }
+
+    -- Tests get a looser selene config (busted/luassert globals).
+    -- nvim-lint requires `args` to be a table, so resolve it per-buffer
+    -- and assign just before each try_lint() call.
+    local function selene_args_for_buffer()
       local file = vim.api.nvim_buf_get_name(0)
       if file:match("/tests/") then
         return { "--display-style", "json", "--config", "tests/selene.toml", "-" }
       end
       return { "--display-style", "json", "-" }
     end
-    lint.linters_by_ft = {
-      lua = { "selene" },
-      markdown = { "markdownlint-cli2" },
-      sh = { "shellcheck" },
-    }
+
     -- Persistent autocmd for all future lint triggers
     vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
       group = vim.api.nvim_create_augroup("__personal_nvim_lint", { clear = true }),
       callback = function()
-        if vim.bo.modifiable then
-          require("lint").try_lint()
+        if not vim.bo.modifiable then
+          return
         end
+        lint.linters.selene.args = selene_args_for_buffer()
+        lint.try_lint()
       end,
     })
+
     -- Lint the current buffer immediately
     if vim.bo.modifiable then
-      require("lint").try_lint()
+      lint.linters.selene.args = selene_args_for_buffer()
+      lint.try_lint()
     end
   end,
 })


### PR DESCRIPTION
nvim-lint requires linter.args to be a table — assigning a function caused
vim.tbl_map(eval, linter.args) to call pairs() on a function, crashing
with "expected table, got function" from vim/shared.lua on every
BufReadPost for Lua files.

Move the test-vs-non-test branch into a selene_args_for_buffer() helper
that returns a plain table, called just before each try_lint().