### PR TITLE
Fix <leader>bd which-key spec using positional desc instead of key

### DIFF
--- a/plugin/which-key.lua
+++ b/plugin/which-key.lua
@@ -23,7 +23,7 @@ vim.schedule(function()
       { "<leader>bn", Cmd("bnext"), desc = "Next Buffer" },
       { "<leader>bp", Cmd("bprevious"), desc = "Prev Buffer" },
       { "<leader>bb", function() Snacks.picker.buffers() end, desc = "Show Open Buffers" },
-      { "<leader>bd", function() Snacks.bufdelete() end, { desc = "Delete Buffer" } },
+      { "<leader>bd", function() Snacks.bufdelete() end, desc = "Delete Buffer" },
       { "<leader>bD", function() Snacks.bufdelete.other() end, desc = "Delete Other Buffers" },
       { "<leader>by", Cmd("%y"), desc = "Copy Buffer Text" },
       { "<leader>bs", function () Snacks.picker.lines() end, desc = "Search Buffer Lines"},


### PR DESCRIPTION
The spec entry used { desc = "Delete Buffer" } as a third positional
element instead of desc = "Delete Buffer" as a direct key on the spec
table, mismatching the which-key v3 format used by every other entry.