### PR TITLE
Add vertical window margin to incline

### DIFF
--- a/plugin/incline.lua
+++ b/plugin/incline.lua
@@ -8,7 +8,7 @@ vim.pack.add({
 require("incline").setup({
   window = {
     padding = 0,
-    margin = { horizontal = 0 },
+    margin = { horizontal = 0, vertical = 2 },
     placement = { vertical = "bottom", horizontal = "right" },
   },
   ignore = {


### PR DESCRIPTION
Adds `vertical = 2` to the incline window margin config so the floating filename bar has breathing room from the top/bottom of the viewport.