### PR TITLE
Disable mason-lspconfig automatic_enable to prevent stylua LSP error

### DIFF
--- a/plugin/lsp.lua
+++ b/plugin/lsp.lua
@@ -84,4 +84,4 @@ require("mason").setup({
     "yamlfmt",
   },
 })
-require("mason-lspconfig").setup()
+require("mason-lspconfig").setup({ automatic_enable = false })


### PR DESCRIPTION
mason-lspconfig v2 defaults `automatic_enable = true`, which iterates all installed Mason packages and calls `vim.lsp.enable()` for any that map to an lspconfig entry. nvim-lspconfig now ships a `stylua` LSP config with `cmd = { "stylua", "--lsp" }`, causing Neovim to spawn stylua as an LSP server on every Lua file open. Since stylua is a formatter (not an LSP), it rejects `--lsp` and logs an error.

Passing `automatic_enable = false` stops the auto-enable. The existing explicit `vim.lsp.enable({...})` on line 67 already handles real LSPs, and conform.nvim continues to use stylua as a formatter unaffected.