### PR TITLE
Fix mini.files <CR> auto-apply on pending edits

### DIFF
--- a/plugin/mini.lua
+++ b/plugin/mini.lua
@@ -173,16 +173,28 @@ vim.api.nvim_create_autocmd("User", {
     local buf = args.data.buf_id
     local files = require("mini.files")
 
-    -- <CR>: open the file under the cursor (closing the explorer) or
-    -- expand a directory in a new column. If the cursor is on a freshly
-    -- typed line that doesn't exist on disk yet, synchronize first so
-    -- mini.files creates the entry, then open it.
+    -- <CR>: open file (closing the explorer) or expand directory. If the
+    -- buffer has pending edits, apply them first so go_in's close_on_file
+    -- doesn't trip the "Close without synchronization?" prompt.
+    -- synchronize() always calls vim.fn.confirm; stub it to return 1 (Yes)
+    -- so fs actions apply silently.
     vim.keymap.set("n", "<CR>", function()
+      if vim.bo[buf].modified then
+        local orig_confirm = vim.fn.confirm
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = function()
+          return 1
+        end
+        local ok, err = pcall(files.synchronize)
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = orig_confirm
+        if not ok then
+          vim.notify(tostring(err), vim.log.levels.ERROR)
+          return
+        end
+      end
       local entry = files.get_fs_entry()
       if entry then
-        files.go_in({ close_on_file = true })
-      else
-        files.synchronize()
         files.go_in({ close_on_file = true })
       end
     end, { buffer = buf, desc = "Open file or expand directory" })


### PR DESCRIPTION
## Summary

Pressing `<CR>` in a `mini.files` explorer buffer that has unsaved edits (rename, new entry) no longer trips the "Close without synchronization?" prompt and no longer opens the pre-rename file. Pending filesystem actions are now applied silently before the entry is opened.

## The bug

The buffer-local `<CR>` mapping called `files.go_in({ close_on_file = true })` whenever `files.get_fs_entry()` returned an entry. Two failure modes followed:

- **Rename case** — `get_fs_entry()` returns the *original* entry (path_id is preserved across edits), so `go_in` runs with `close_on_file = true`. Closing the explorer with pending fs_actions triggers the wrong prompt ("Close without synchronization?") instead of the normal sync confirmation. If the user accepted, the original file opened — not the renamed one.
- **Close-on-file fallthrough** — even when the sync prompt did fire (new-entry case), the subsequent `go_in` still tried to open a line whose path_id no longer matched disk.

## Fix

- Detect unsaved edits via `vim.bo[buf].modified` and synchronize before opening.
- `mini.files.synchronize()` unconditionally calls `vim.fn.confirm(...)`; with no public knob to skip the prompt (and `:silent write` makes `confirm` return `0`, not the default button, so fs_actions are dropped), stub `vim.fn.confirm` to return `1` (Yes) for the duration of a single `synchronize()` call. Restore the original in both success and error paths via `pcall`.
- After sync, the entry under the cursor matches disk and `go_in({ close_on_file = true })` opens it cleanly.

Suppress lua_ls `duplicate-set-field` on the two `vim.fn.confirm = …` assignments (runtime-only concern).

## Files

- `plugin/mini.lua` — keymap body + comment block

## Verification

- `just check` — clean (selene 0/0, stylua clean, 124 tests pass).
- Rename `foo.txt` → `foo.tx` in the explorer, `<Esc>`, `<CR>` → rename applies, renamed file opens, no prompt.
- Create a new entry on a blank line, `<Esc>`, `<CR>` → file created, opened, no prompt.
- `<CR>` on an unmodified entry → opens normally (regression check).
- `<CR>` on a directory → expands in a new column (regression check).
- `<C-s>`, `q`, `<Esc>` keymaps unchanged.