### PR TITLE
Scroll LSP hover popup with Shift+J/Shift+K

### DIFF
--- a/lua/config/helpers.lua
+++ b/lua/config/helpers.lua
@@ -16,4 +16,19 @@ function M.close_all_floating_wins()
   end
 end
 
+---Scroll the LSP hover popup, if one is open for the current buffer.
+---@param direction "down"|"up"
+---@return boolean scrolled true if a hover popup was found and scrolled
+function M.scroll_hover(direction)
+  local ok, winid = pcall(vim.api.nvim_buf_get_var, 0, "lsp_floating_preview")
+  if not ok or not winid or not vim.api.nvim_win_is_valid(winid) then
+    return false
+  end
+  local key = vim.api.nvim_replace_termcodes(direction == "down" and "<C-d>" or "<C-u>", true, false, true)
+  vim.api.nvim_win_call(winid, function()
+    vim.cmd("normal! " .. key)
+  end)
+  return true
+end
+
 return M

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,5 +1,6 @@
 local map = vim.keymap.set
-local Cmd = require("config.helpers").Cmd
+local helpers = require("config.helpers")
+local Cmd = helpers.Cmd
 
 -- Unmap 'q'
 map("n", "q", "<nop>", { remap = false })
@@ -27,9 +28,21 @@ map("n", "<A-s>", Cmd("resize -2"), { desc = "Decrease Window Height" })
 map("n", "<A-a>", Cmd("vertical resize -2"), { desc = "Decrease Window Width" })
 map("n", "<A-d>", Cmd("vertical resize +2"), { desc = "Increase Window Width" })
 
--- Move Lines
-map("n", "J", "<cmd>execute 'move .+' . v:count1<cr>==", { desc = "Move Down" })
-map("n", "K", "<cmd>execute 'move .-' . (v:count1 + 1)<cr>==", { desc = "Move Up" })
+-- Move Lines (scrolls LSP hover popup first, if one is open)
+map("n", "J", function()
+  if helpers.scroll_hover("down") then
+    return
+  end
+  vim.cmd("execute 'move .+' . v:count1")
+  vim.cmd("normal! ==")
+end, { desc = "Scroll Hover / Move Down" })
+map("n", "K", function()
+  if helpers.scroll_hover("up") then
+    return
+  end
+  vim.cmd("execute 'move .-' . (v:count1 + 1)")
+  vim.cmd("normal! ==")
+end, { desc = "Scroll Hover / Move Up" })
 map("v", "J", ":<C-u>execute \"'<,'>move '>+\" . v:count1<cr>gv=gv", { desc = "Move Down" })
 map("v", "K", ":<C-u>execute \"'<,'>move '<-\" . (v:count1 + 1)<cr>gv=gv", { desc = "Move Up" })
 


### PR DESCRIPTION
## Summary

Make `Shift+J` and `Shift+K` scroll the LSP hover popup while it's open — then revert to the existing move-line behavior once the popup is dismissed. No mode, no setup/teardown to remember.

## Key changes

- `lua/config/helpers.lua` — new `scroll_hover(direction)` reads `vim.b.lsp_floating_preview` (set by `vim.lsp.util.open_floating_preview`), validates the window, and scrolls it with `<C-d>` / `<C-u>` via `vim.api.nvim_win_call`. Returns `false` when no popup is open.
- `lua/config/keymaps.lua` — normal-mode `J` / `K` now call `helpers.scroll_hover` first, falling through to the existing `move .+` / `move .-` commands when no popup is open.

## Decisions

- **Dynamic dispatch, not a mode.** Each keypress checks for a valid popup winid — no need to install/uninstall mappings around `gh`, and the popup's own lifecycle (CursorMoved, BufLeave) still handles cleanup.
- **Scrolling via `nvim_win_call` inside the float.** The main buffer's cursor doesn't move, so Neovim's "close popup on CursorMoved" autocmd doesn't fire — the popup stays open across repeated scrolls.
- **Normal mode only.** Visual-mode `J` / `K` (move selected lines) are untouched.
- **Scope.** Works for any popup that flows through `vim.lsp.util.open_floating_preview` (hover, signature help, etc.), since they all set `vim.b.lsp_floating_preview`.

## Reviewer notes

- `gh` itself is unchanged.
- `3J` still moves the current line down three times via the fallback branch (count is preserved).
- `just check` passes — selene 0/0, stylua clean, 124 tests.