### PR TITLE
Keep netrw alongside snacks explorer

### DIFF
--- a/plugin/snacks.lua
+++ b/plugin/snacks.lua
@@ -5,7 +5,7 @@ vim.pack.add({ "https://github.com/folke/snacks.nvim" })
 
 require("snacks").setup({
   bigfile = { enabled = true },
-  explorer = { enabled = true },
+  explorer = { enabled = true, replace_netrw = false },
   indent = { enabled = true },
   input = { enabled = true },
   image = { enabled = true },


### PR DESCRIPTION
## Summary

Set `explorer.replace_netrw = false` in the snacks.nvim config so Neovim's built-in `netrw` remains available for directory buffers instead of being shadowed by `snacks.explorer`.

## Key changes

- `plugin/snacks.lua` — add `replace_netrw = false` to the `explorer` entry in the `snacks.setup(...)` call.

## Reviewer notes

- One-line config tweak; no other behavior changes.
- `snacks.explorer` itself is still enabled — only the netrw-replacement hook is opted out.