### PR TITLE
Move helpers out of config namespace

### DIFF
--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -18,7 +18,7 @@ Rules for adding features to this Neovim configuration. See `CLAUDE.md` at the r
 
 Edit the appropriate file in `lua/config/`:
 - **Options/globals**: `options.lua`
-- **Keybindings**: `keymaps.lua` (use `require("config.helpers").Cmd()` for command mappings)
+- **Keybindings**: `keymaps.lua` (use `require("helpers.mappings").Cmd()` for command mappings)
 - **Autocommands**: `autocmds.lua` (every autocmd **must** have a comment explaining what/why/when)
 - **Highlight groups**: `highlights.lua`
 

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,6 +1,6 @@
 local map = vim.keymap.set
-local helpers = require("config.helpers")
-local Cmd = helpers.Cmd
+local Cmd = require("helpers.mappings").Cmd
+local windows = require("helpers.windows")
 
 -- Unmap 'q'
 map("n", "q", "<nop>", { remap = false })
@@ -30,14 +30,14 @@ map("n", "<A-d>", Cmd("vertical resize +2"), { desc = "Increase Window Width" })
 
 -- Move Lines (scrolls LSP hover popup first, if one is open)
 map("n", "J", function()
-  if helpers.scroll_hover("down") then
+  if windows.scroll_hover("down") then
     return
   end
   vim.cmd("execute 'move .+' . v:count1")
   vim.cmd("normal! ==")
 end, { desc = "Scroll Hover / Move Down" })
 map("n", "K", function()
-  if helpers.scroll_hover("up") then
+  if windows.scroll_hover("up") then
     return
   end
   vim.cmd("execute 'move .-' . (v:count1 + 1)")

--- a/lua/helpers/mappings.lua
+++ b/lua/helpers/mappings.lua
@@ -1,0 +1,51 @@
+local M = {}
+
+---Convenience function that wraps the given string with `<Cmd>` and `<CR>`.
+---@param command string The command to wrap.
+---@return string wrapped The command surrounded by `<Cmd>...<CR>`.
+function M.Cmd(command)
+  return "<Cmd>" .. command .. "<CR>"
+end
+
+---@class helpers.mappings.Opts
+---@field buffer? integer|boolean         Buffer-local mapping. `true` = current buffer, integer = specific buffer.
+---@field silent? boolean                 Suppress command-line output.
+---@field remap? boolean                  Allow recursive remapping (default false, matching `vim.keymap.set`).
+---@field expr? boolean                   Evaluate `rhs` as a Vim expression.
+---@field nowait? boolean                 Don't wait for more keys after a match.
+---@field script? boolean                 Remap only script-local mappings.
+---@field unique? boolean                 Fail if a mapping already exists for `lhs`.
+---@field replace_keycodes? boolean       For expr mappings, replace keycodes in the returned string (default true when `expr` is true).
+
+---Create a key mapping with the description, mode, lhs, and rhs required up front.
+---
+---This is a thin, behavior-preserving wrapper over `vim.keymap.set`. Its only
+---purpose is readability: putting `desc` first makes the mapping's intent
+---visible at a glance, instead of being buried after a multi-line `rhs`.
+---
+---All four leading parameters are required positional arguments; omitting any
+---of them raises a Lua error at the call site. Every field of
+---`vim.keymap.set`'s `{opts}` except `desc` is supported via the trailing
+---`opts` table.
+---
+---@param desc string                    Human-readable description (shown in which-key / `:verbose map`).
+---@param mode string|string[]           Mode(s) the mapping applies to — e.g. `"n"`, `{ "n", "x" }`, `"i"`.
+---@param lhs string                     Left-hand side — the key sequence to press.
+---@param rhs string|function            Right-hand side — a Vim keystroke string or a Lua callback.
+---@param opts? helpers.mappings.Opts    Remaining `vim.keymap.set` options.
+function M.map(desc, mode, lhs, rhs, opts)
+  opts = opts or {}
+  vim.keymap.set(mode, lhs, rhs, {
+    desc = desc,
+    buffer = opts.buffer,
+    silent = opts.silent,
+    remap = opts.remap,
+    expr = opts.expr,
+    nowait = opts.nowait,
+    script = opts.script,
+    unique = opts.unique,
+    replace_keycodes = opts.replace_keycodes,
+  })
+end
+
+return M

--- a/lua/helpers/windows.lua
+++ b/lua/helpers/windows.lua
@@ -1,11 +1,5 @@
 local M = {}
 
----Convenience function that wraps the given string with `<Cmd>` and `<CR>`
----@param command string The command to wrap.
-function M.Cmd(command)
-  return "<Cmd>" .. command .. "<CR>"
-end
-
 ---Closes floating windows - especially useful in auto-session, to make sure that things are restored properly
 function M.close_all_floating_wins()
   for _, win in ipairs(vim.api.nvim_list_wins()) do

--- a/plugin/auto-session.lua
+++ b/plugin/auto-session.lua
@@ -3,5 +3,5 @@
 vim.pack.add({ "https://github.com/rmagatti/auto-session" })
 require("auto-session").setup({
   suppressed_dirs = { "~/", "~/Projects", "~/Downloads", "/" },
-  pre_save_cmds = { require("config.helpers").close_all_floating_wins },
+  pre_save_cmds = { require("helpers.windows").close_all_floating_wins },
 })

--- a/plugin/which-key.lua
+++ b/plugin/which-key.lua
@@ -5,7 +5,7 @@ vim.pack.add({ "https://github.com/folke/which-key.nvim" }, { load = false })
 vim.schedule(function()
   vim.cmd.packadd("which-key.nvim")
 
-  local Cmd = require("config.helpers").Cmd
+  local Cmd = require("helpers.mappings").Cmd
   local Snacks = require("snacks")
 
   require("which-key").setup({


### PR DESCRIPTION
## Summary

Split `lua/config/helpers.lua` into a new top-level `lua/helpers/` namespace, one module per concern.

## Changes

- **`lua/helpers/mappings.lua`** *(new)* — houses the existing `Cmd` wrapper plus a new `map` helper that puts `desc` first (readable intent up front), exposing the rest of `vim.keymap.set`'s `{opts}` via a typed `helpers.mappings.Opts` class.
- **`lua/helpers/windows.lua`** *(renamed from `lua/config/helpers.lua`)* — keeps `close_all_floating_wins` and `scroll_hover` on their own, away from mapping concerns.
- **Call sites updated** — `lua/config/keymaps.lua`, `plugin/auto-session.lua`, and `plugin/which-key.lua` now `require("helpers.mappings")` / `require("helpers.windows")`.
- **Docs** — `.claude/rules/development.md` updated to reference the new path.

## Notes for reviewers

- Pure refactor — no behavior change for existing callers.
- The new `map` helper is introduced in the same file but is not yet used anywhere; it's available for future migrations.
- No tests affected.