### PR TITLE
Add catppuccin color scheme

### DIFF
--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -128,6 +128,10 @@
       "rev": "7bfd942445fb63089b59f97ca487d605e715f155",
       "src": "https://github.com/folke/noice.nvim"
     },
+    "nordic.nvim": {
+      "rev": "c38a210bdaf79e74823d88c741029cac7f6b4481",
+      "src": "https://github.com/AlexvZyl/nordic.nvim"
+    },
     "nui.nvim": {
       "rev": "de740991c12411b663994b2860f1a4fd0937c130",
       "src": "https://github.com/MunifTanjim/nui.nvim"
@@ -135,6 +139,10 @@
     "numb.nvim": {
       "rev": "12ef3913dea8727d4632c6f2ed47957a993de627",
       "src": "https://github.com/nacro90/numb.nvim"
+    },
+    "nvim": {
+      "rev": "426dbebe06b5c69fd846ceb17b42e12f890aedf1",
+      "src": "https://github.com/catppuccin/nvim"
     },
     "nvim-bqf": {
       "rev": "c282a62bec6c0621a1ef5132aa3f4c9fc4dcc2c7",

--- a/plugin/catppuccin.lua
+++ b/plugin/catppuccin.lua
@@ -1,0 +1,24 @@
+-- github.com/catppuccin/nvim
+-- Nice color scheme
+vim.pack.add({ "https://github.com/catppuccin/nvim" })
+
+require("catppuccin").setup({
+  transparent_background = true,
+  background = { dark = "mocha" },
+  float = { transparent = true, solid = false },
+})
+
+vim.cmd.colorscheme("catppuccin-nvim")
+
+-- Catppuccin links BlinkCmpMenu to Pmenu, which keeps a surface0 bg even when
+-- transparent_background is enabled. Clear the bg so the completion popup
+-- matches the terminal background like the other floats.
+vim.api.nvim_create_autocmd("ColorScheme", {
+  pattern = "catppuccin*",
+  callback = function()
+    vim.api.nvim_set_hl(0, "BlinkCmpMenu", { bg = "NONE" })
+    vim.api.nvim_set_hl(0, "BlinkCmpDoc", { bg = "NONE" })
+  end,
+})
+vim.api.nvim_set_hl(0, "BlinkCmpMenu", { bg = "NONE" })
+vim.api.nvim_set_hl(0, "BlinkCmpDoc", { bg = "NONE" })


### PR DESCRIPTION
## Summary

Install `catppuccin/nvim` and set the **mocha** variant as the active colorscheme with a transparent background.

## Changes

- **`plugin/catppuccin.lua`** *(new)* — `vim.pack.add` + `setup({ transparent_background = true, background = { dark = "mocha" }, float = { transparent = true, solid = false } })`, followed by `vim.cmd.colorscheme("catppuccin-nvim")`.
- **`ColorScheme` autocmd** — clears `BlinkCmpMenu` and `BlinkCmpDoc` backgrounds (catppuccin links `BlinkCmpMenu` to `Pmenu`, which keeps a `surface0` bg even with transparency enabled).
- **`nvim-pack-lock.json`** — new entries for `catppuccin/nvim` and `AlexvZyl/nordic.nvim`.

## Notes for reviewers

- **`nordic.nvim` lockfile entry** — no corresponding plugin file exists; it was picked up while evaluating alternatives. Flag if you'd rather prune it before merging.
- The `ColorScheme` autocmd will interact with any explicit `BlinkCmp*` highlights (see the `style-highlights-tweaks` branch) — whichever runs last wins.