### PR TITLE
Migrate vim.keymap.set call sites to helpers.mappings.map

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -1,3 +1,5 @@
+local map = require("helpers.mappings").map
+
 local function augroup(name)
   return vim.api.nvim_create_augroup("__personal_" .. name, { clear = true })
 end
@@ -102,13 +104,12 @@ vim.api.nvim_create_autocmd("FileType", {
   callback = function(event)
     vim.bo[event.buf].buflisted = false
     vim.schedule(function()
-      vim.keymap.set("n", "q", function()
+      map("Quit buffer", "n", "q", function()
         vim.cmd("close")
         pcall(vim.api.nvim_buf_delete, event.buf, { force = true })
       end, {
         buffer = event.buf,
         silent = true,
-        desc = "Quit buffer",
       })
     end)
   end,

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,82 +1,82 @@
-local map = vim.keymap.set
+local map = require("helpers.mappings").map
 local Cmd = require("helpers.mappings").Cmd
 local windows = require("helpers.windows")
 
 -- Unmap 'q'
-map("n", "q", "<nop>", { remap = false })
+map("Unmap q", "n", "q", "<nop>")
 
 -- Don't copy things you've pasted over
-map("v", "p", '"_dP')
+map("No-yank paste", "v", "p", '"_dP')
 
 -- make 'Y' yank from current character to end of line
-map("n", "Y", "y$", { desc = "Yank to Line End" })
-map("v", "y", "ygv<ESC>")
+map("Yank to Line End", "n", "Y", "y$")
+map("Yank and reselect", "v", "y", "ygv<ESC>")
 
 -- better up/down
-map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
-map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
-map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
-map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map("Down", { "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+map("Down", { "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+map("Down", { "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+map("Down", { "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+map("Up", { "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
+map("Up", { "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
+map("Up", { "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
+map("Up", { "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 
 -- Resize windows using Alt+WASD
-map("n", "<A-w>", Cmd("resize +2"), { desc = "Increase Window Height" })
-map("n", "<A-s>", Cmd("resize -2"), { desc = "Decrease Window Height" })
-map("n", "<A-a>", Cmd("vertical resize -2"), { desc = "Decrease Window Width" })
-map("n", "<A-d>", Cmd("vertical resize +2"), { desc = "Increase Window Width" })
+map("Increase Window Height", "n", "<A-w>", Cmd("resize +2"))
+map("Decrease Window Height", "n", "<A-s>", Cmd("resize -2"))
+map("Decrease Window Width", "n", "<A-a>", Cmd("vertical resize -2"))
+map("Increase Window Width", "n", "<A-d>", Cmd("vertical resize +2"))
 
 -- Move Lines (scrolls LSP hover popup first, if one is open)
-map("n", "J", function()
+map("Scroll Hover / Move Down", "n", "J", function()
   if windows.scroll_hover("down") then
     return
   end
   vim.cmd("execute 'move .+' . v:count1")
   vim.cmd("normal! ==")
-end, { desc = "Scroll Hover / Move Down" })
-map("n", "K", function()
+end)
+map("Scroll Hover / Move Up", "n", "K", function()
   if windows.scroll_hover("up") then
     return
   end
   vim.cmd("execute 'move .-' . (v:count1 + 1)")
   vim.cmd("normal! ==")
-end, { desc = "Scroll Hover / Move Up" })
-map("v", "J", ":<C-u>execute \"'<,'>move '>+\" . v:count1<cr>gv=gv", { desc = "Move Down" })
-map("v", "K", ":<C-u>execute \"'<,'>move '<-\" . (v:count1 + 1)<cr>gv=gv", { desc = "Move Up" })
+end)
+map("Move Down", "v", "J", ":<C-u>execute \"'<,'>move '>+\" . v:count1<cr>gv=gv")
+map("Move Up", "v", "K", ":<C-u>execute \"'<,'>move '<-\" . (v:count1 + 1)<cr>gv=gv")
 
 -- Better indentation
-map("v", "<", "<gv")
-map("v", ">", ">gv")
+map("Indent left and reselect", "v", "<", "<gv")
+map("Indent right and reselect", "v", ">", ">gv")
 
 -- Clear search and stop snippet on escape
-map({ "i", "n", "s" }, "<esc>", function()
+map("Escape and Clear hlsearch", { "i", "n", "s" }, "<esc>", function()
   vim.cmd("noh")
   return "<esc>"
-end, { expr = true, desc = "Escape and Clear hlsearch" })
+end, { expr = true })
 
 -- Add undo break-points
-map("i", ",", ",<c-g>u")
-map("i", ".", ".<c-g>u")
-map("i", ";", ";<c-g>u")
+map("Undo break-point at ,", "i", ",", ",<c-g>u")
+map("Undo break-point at .", "i", ".", ".<c-g>u")
+map("Undo break-point at ;", "i", ";", ";<c-g>u")
 
 -- Save, no matter what
-map({ "i", "x", "n", "s" }, "<C-s>", "<cmd>w<cr><esc>", { desc = "Save File" })
+map("Save File", { "i", "x", "n", "s" }, "<C-s>", "<cmd>w<cr><esc>")
 
 -- Dupe lines up/down
-map("n", "<A-j>", Cmd("t."), { desc = "Copy line down" })
-map("n", "<A-k>", Cmd("t-1"), { desc = "Copy line up" })
-map("v", "<A-j>", "y`>pgv", { desc = "Copy lines down" })
-map("v", "<A-k>", "y`<Pgv", { desc = "Copy line up" })
+map("Copy line down", "n", "<A-j>", Cmd("t."))
+map("Copy line up", "n", "<A-k>", Cmd("t-1"))
+map("Copy lines down", "v", "<A-j>", "y`>pgv")
+map("Copy line up", "v", "<A-k>", "y`<Pgv")
 
 -- Terminal
-map("n", "<C-'>", function()
+map("Terminal", "n", "<C-'>", function()
   Snacks.terminal()
-end, { desc = "Terminal" })
-map("t", "<C-'>", function()
+end)
+map("Terminal", "t", "<C-'>", function()
   Snacks.terminal()
-end, { desc = "Terminal" })
+end)
 
 -- Focus Neotree using CTRL-\
 local function neo_tree_focus_toggle()
@@ -98,25 +98,25 @@ local function neo_tree_focus_toggle()
   vim.cmd("Neotree focus right")
 end
 
-vim.keymap.set("n", "<C-\\>", neo_tree_focus_toggle, { noremap = true, silent = true })
+map("Toggle neo-tree focus", "n", "<C-\\>", neo_tree_focus_toggle, { silent = true })
 
 -- Join the next/prev line with the current
-map("n", "<A-J>", Cmd("norm! J"), { desc = "Join Current Line w/ Next" })
-map("n", "<A-K>", Cmd(".-1,.join"), { desc = "Join Current Line w/ Prev" })
+map("Join Current Line w/ Next", "n", "<A-J>", Cmd("norm! J"))
+map("Join Current Line w/ Prev", "n", "<A-K>", Cmd(".-1,.join"))
 
 -- Select parent/child treesitter node (falls back to LSP selection range)
-map({ "n", "x", "o" }, "<A-o>", function()
+map("Select Parent Node", { "n", "x", "o" }, "<A-o>", function()
   if vim.treesitter.get_parser(nil, nil, { error = false }) then
     require("vim.treesitter._select").select_parent(vim.v.count1)
   else
     vim.lsp.buf.selection_range(vim.v.count1)
   end
-end, { desc = "Select Parent Node" })
+end)
 
-map({ "n", "x", "o" }, "<A-i>", function()
+map("Select Child Node", { "n", "x", "o" }, "<A-i>", function()
   if vim.treesitter.get_parser(nil, nil, { error = false }) then
     require("vim.treesitter._select").select_child(vim.v.count1)
   else
     vim.lsp.buf.selection_range(-vim.v.count1)
   end
-end, { desc = "Select Child Node" })
+end)

--- a/plugin/dial.lua
+++ b/plugin/dial.lua
@@ -2,6 +2,8 @@
 -- Increment and decrement numbers, dates, booleans, and more with C-a/C-x
 vim.pack.add({ "https://github.com/monaqa/dial.nvim" }, { load = false })
 
+local map = require("helpers.mappings").map
+
 -- Build the dial.map function name for the current context and invoke it.
 -- Combines the direction (inc/dec), the "g" prefix variant (for g<C-a>),
 -- and the mode (visual/normal) into a function name like "inc_normal" or
@@ -157,8 +159,8 @@ local function ensure_loaded()
 end
 
 -- stylua: ignore start
-vim.keymap.set({ "n", "v" }, "<C-a>", function() ensure_loaded(); return dial(true) end, { expr = true, desc = "Increment" })
-vim.keymap.set({ "n", "v" }, "<C-x>", function() ensure_loaded(); return dial(false) end, { expr = true, desc = "Decrement" })
-vim.keymap.set({ "n", "v" }, "g<C-a>", function() ensure_loaded(); return dial(true, true) end, { expr = true, desc = "Increment" })
-vim.keymap.set({ "n", "v" }, "g<C-x>", function() ensure_loaded(); return dial(false, true) end, { expr = true, desc = "Decrement" })
+map("Increment", { "n", "v" }, "<C-a>", function() ensure_loaded(); return dial(true) end, { expr = true })
+map("Decrement", { "n", "v" }, "<C-x>", function() ensure_loaded(); return dial(false) end, { expr = true })
+map("Increment", { "n", "v" }, "g<C-a>", function() ensure_loaded(); return dial(true, true) end, { expr = true })
+map("Decrement", { "n", "v" }, "g<C-x>", function() ensure_loaded(); return dial(false, true) end, { expr = true })
 -- stylua: ignore end

--- a/plugin/flash.lua
+++ b/plugin/flash.lua
@@ -2,11 +2,13 @@
 -- Jump anywhere on screen with labeled targets via 's'
 vim.pack.add({ "https://github.com/folke/flash.nvim" }, { load = false })
 
-vim.keymap.set({ "n", "x", "o" }, "s", function()
+local map = require("helpers.mappings").map
+
+map("Flash", { "n", "x", "o" }, "s", function()
   vim.cmd.packadd("flash.nvim")
   -- Replace this stub with the real keymap
-  vim.keymap.set({ "n", "x", "o" }, "s", function()
+  map("Flash", { "n", "x", "o" }, "s", function()
     require("flash").jump()
-  end, { desc = "Flash" })
+  end)
   require("flash").jump()
-end, { desc = "Flash" })
+end)

--- a/plugin/illuminate.lua
+++ b/plugin/illuminate.lua
@@ -28,10 +28,12 @@ vim.schedule(function()
     :map("<leader>ux")
 end)
 
+local map = require("helpers.mappings").map
+
 local function map_ref(key, dir, buffer)
-  vim.keymap.set("n", key, function()
+  map(dir:sub(1, 1):upper() .. dir:sub(2) .. " Reference", "n", key, function()
     require("illuminate")["goto_" .. dir .. "_reference"](false)
-  end, { desc = dir:sub(1, 1):upper() .. dir:sub(2) .. " Reference", buffer = buffer })
+  end, { buffer = buffer })
 end
 
 map_ref("]]", "next")

--- a/plugin/lsp.lua
+++ b/plugin/lsp.lua
@@ -6,13 +6,10 @@ vim.pack.add({
 })
 
 -- LSP keymaps
-local map = vim.keymap.set
-local function noremap(desc)
-  return { noremap = true, silent = true, desc = desc }
-end
+local map = require("helpers.mappings").map
 
 -- If the cursor is on a URL, open it in the browser; otherwise go to definition
-map("n", "gd", function()
+map("Goto Definition / Open URL", "n", "gd", function()
   local word = vim.fn.expand("<cWORD>")
   local url = word:match("(https?://[%w_.~!*'();:@&=+$,/?#%%[%]%-]+)")
   if url then
@@ -20,20 +17,20 @@ map("n", "gd", function()
   else
     vim.lsp.buf.definition()
   end
-end, noremap("Goto Definition / Open URL"))
-map("n", "gD", function()
+end, { silent = true })
+map("Goto Definition in Split", "n", "gD", function()
   vim.cmd("vsplit")
   vim.lsp.buf.definition()
-end, noremap("Goto Definition in Split"))
-map("n", "gh", function()
+end, { silent = true })
+map("Show Hover", "n", "gh", function()
   vim.lsp.buf.hover({ border = "rounded", max_width = 80 })
-end, noremap("Show Hover"))
-map("n", "gr", vim.lsp.buf.references, noremap("Goto References"))
-map("n", "gi", vim.lsp.buf.implementation, noremap("Goto Implementation"))
-map("n", "gy", vim.lsp.buf.type_definition, noremap("Goto T[y]pe Definition"))
-map("i", "<C-k>", function()
+end, { silent = true })
+map("Goto References", "n", "gr", vim.lsp.buf.references, { silent = true })
+map("Goto Implementation", "n", "gi", vim.lsp.buf.implementation, { silent = true })
+map("Goto T[y]pe Definition", "n", "gy", vim.lsp.buf.type_definition, { silent = true })
+map("Show Signature Help", "i", "<C-k>", function()
   vim.lsp.buf.signature_help({ border = "rounded", max_width = 80 })
-end, noremap("Show Signature Help"))
+end, { silent = true })
 
 -- LSP server configs
 vim.lsp.config("jsonnet_ls", {

--- a/plugin/mini.lua
+++ b/plugin/mini.lua
@@ -22,6 +22,7 @@ vim.api.nvim_create_autocmd("ColorScheme", { callback = set_statusline_highlight
 set_statusline_highlights()
 
 local pack_updates = require("config.pack-updates")
+local map = require("helpers.mappings").map
 
 -- Custom statusline section: shows a braille spinner while checking
 -- for plugin updates, then icon + count when updates are available.
@@ -178,7 +179,7 @@ vim.api.nvim_create_autocmd("User", {
     -- doesn't trip the "Close without synchronization?" prompt.
     -- synchronize() always calls vim.fn.confirm; stub it to return 1 (Yes)
     -- so fs actions apply silently.
-    vim.keymap.set("n", "<CR>", function()
+    map("Open file or expand directory", "n", "<CR>", function()
       if vim.bo[buf].modified then
         local orig_confirm = vim.fn.confirm
         ---@diagnostic disable-next-line: duplicate-set-field
@@ -197,7 +198,7 @@ vim.api.nvim_create_autocmd("User", {
       if entry then
         files.go_in({ close_on_file = true })
       end
-    end, { buffer = buf, desc = "Open file or expand directory" })
+    end, { buffer = buf })
 
     -- Route :w through BufWriteCmd. mini.files creates scratch buffers
     -- (buftype=nofile) which would otherwise reject :w with E382.
@@ -230,18 +231,18 @@ vim.api.nvim_create_autocmd("User", {
     -- vim.fn.confirm returns its default (Yes) without prompting — silently
     -- auto-applying changes. Feeding <Esc> afterwards exits insert/visual
     -- mode so the keymap behaves consistently across modes.
-    vim.keymap.set({ "n", "i", "x", "s" }, "<C-s>", function()
+    map("Synchronize mini.files", { "n", "i", "x", "s" }, "<C-s>", function()
       files.synchronize()
       local esc = vim.api.nvim_replace_termcodes("<Esc>", true, false, true)
       vim.api.nvim_feedkeys(esc, "n", false)
-    end, { buffer = buf, desc = "Synchronize mini.files" })
+    end, { buffer = buf })
 
     -- H: jump the explorer back to the current working directory.
     -- Useful when nested deep in a tree and you want to start over from
     -- the project root without closing and reopening the explorer.
-    vim.keymap.set("n", "H", function()
+    map("Go to cwd root", "n", "H", function()
       files.open(vim.uv.cwd(), false)
-    end, { buffer = buf, desc = "Go to cwd root" })
+    end, { buffer = buf })
 
     -- q / <Esc>: close the explorer, synchronizing first so any pending
     -- edits are not silently dropped — the confirm prompt still runs.
@@ -250,15 +251,15 @@ vim.api.nvim_create_autocmd("User", {
       files.close()
     end
 
-    vim.keymap.set("n", "q", sync_and_close, { buffer = buf, desc = "Sync and close" })
-    vim.keymap.set("n", "<Esc>", sync_and_close, { buffer = buf, desc = "Sync and close" })
+    map("Sync and close", "n", "q", sync_and_close, { buffer = buf })
+    map("Sync and close", "n", "<Esc>", sync_and_close, { buffer = buf })
 
     -- mm: cut the entry under the cursor. Stashes the entire buffer line
     -- (including the concealed /<path_id>/ prefix) in a module-local
     -- variable and removes it from the buffer. Preserving the path_id is
     -- what lets a subsequent paste be recognized by mini.files's diff as
     -- a move rather than a delete + create.
-    vim.keymap.set("n", "mm", function()
+    map("Cut entry (paste with p)", "n", "mm", function()
       local lnum = vim.api.nvim_win_get_cursor(0)[1]
       local line = vim.api.nvim_buf_get_lines(buf, lnum - 1, lnum, false)[1]
       if not line or line == "" then
@@ -266,12 +267,12 @@ vim.api.nvim_create_autocmd("User", {
       end
       cut_line = line
       vim.api.nvim_buf_set_lines(buf, lnum - 1, lnum, false, {})
-    end, { buffer = buf, desc = "Cut entry (paste with p)" })
+    end, { buffer = buf })
 
     -- p: paste the previously cut entry below the cursor in any mini.files
     -- buffer. The move is not committed until the user synchronizes
     -- (:w / <C-s> / q), so this is safe to undo by closing without sync.
-    vim.keymap.set("n", "p", function()
+    map("Paste cut entry", "n", "p", function()
       if not cut_line then
         vim.notify("mini.files: nothing to paste", vim.log.levels.WARN)
         return
@@ -279,19 +280,19 @@ vim.api.nvim_create_autocmd("User", {
       local lnum = vim.api.nvim_win_get_cursor(0)[1]
       vim.api.nvim_buf_set_lines(buf, lnum, lnum, false, { cut_line })
       cut_line = nil
-    end, { buffer = buf, desc = "Paste cut entry" })
+    end, { buffer = buf })
 
     -- <M-p>: toggle the preview pane on/off. Flipping the config flag
     -- alone doesn't redraw, so we re-set the current branch to force
     -- mini.files to rebuild the layout with the new preview setting.
-    vim.keymap.set("n", "<M-p>", function()
+    map("Toggle preview pane", "n", "<M-p>", function()
       files.config.windows.preview = not files.config.windows.preview
       local state = files.get_explorer_state()
       if state then
         local branch = vim.list_slice(state.branch, 1, state.depth_focus)
         files.set_branch(branch, { depth_focus = state.depth_focus })
       end
-    end, { buffer = buf, desc = "Toggle preview pane" })
+    end, { buffer = buf })
   end,
 })
 

--- a/plugin/multicursor.lua
+++ b/plugin/multicursor.lua
@@ -13,25 +13,25 @@ hl(0, "MultiCursorDisabledCursor", { link = "Visual" })
 hl(0, "MultiCursorDisabledVisual", { link = "Visual" })
 hl(0, "MultiCursorDisabledSign", { link = "SignColumn" })
 
-local map = vim.keymap.set
+local map = require("helpers.mappings").map
 
 -- stylua: ignore start
-map({ "n", "x" }, "<C-k>", function() mc.lineAddCursor(-1) end, { desc = "Add Cursor Above" })
-map({ "n", "x" }, "<C-S-k>", function() mc.lineAddCursor(-1) end, { desc = "Add Cursor Above" })
-map({ "n", "x" }, "<C-j>", function() mc.lineAddCursor(1) end, { desc = "Add Cursor Below" })
-map({ "n", "x" }, "<C-S-j>", function() mc.lineAddCursor(1) end, { desc = "Add Cursor Below" })
+map("Add Cursor Above", { "n", "x" }, "<C-k>", function() mc.lineAddCursor(-1) end)
+map("Add Cursor Above", { "n", "x" }, "<C-S-k>", function() mc.lineAddCursor(-1) end)
+map("Add Cursor Below", { "n", "x" }, "<C-j>", function() mc.lineAddCursor(1) end)
+map("Add Cursor Below", { "n", "x" }, "<C-S-j>", function() mc.lineAddCursor(1) end)
 
-map({ "n", "x" }, "<C-n>", function() mc.matchAddCursor(1) end, { desc = "Add Cursor to Next Match" })
-map({ "n", "x" }, "gn", function() mc.matchAddCursor(1) end, { desc = "Add Cursor to Next Match" })
-map({ "n", "x" }, "<C-S-n>", function() mc.matchAddCursor(-1) end, { desc = "Add Cursor to Prev Match" })
-map({ "n", "x" }, "gN", function() mc.matchAddCursor(-1) end, { desc = "Add Cursor to Prev Match" })
-map({ "n", "x" }, "gA", function() mc.matchAllAddCursors() end, { desc = "Add Cursor to All Matches" })
+map("Add Cursor to Next Match", { "n", "x" }, "<C-n>", function() mc.matchAddCursor(1) end)
+map("Add Cursor to Next Match", { "n", "x" }, "gn", function() mc.matchAddCursor(1) end)
+map("Add Cursor to Prev Match", { "n", "x" }, "<C-S-n>", function() mc.matchAddCursor(-1) end)
+map("Add Cursor to Prev Match", { "n", "x" }, "gN", function() mc.matchAddCursor(-1) end)
+map("Add Cursor to All Matches", { "n", "x" }, "gA", function() mc.matchAllAddCursors() end)
 
-map("n", "<C-leftmouse>", mc.handleMouse)
-map("n", "<C-leftdrag>", mc.handleMouseDrag)
-map("n", "<C-leftrelease>", mc.handleMouseRelease)
+map("Multicursor mouse down", "n", "<C-leftmouse>", mc.handleMouse)
+map("Multicursor mouse drag", "n", "<C-leftdrag>", mc.handleMouseDrag)
+map("Multicursor mouse release", "n", "<C-leftrelease>", mc.handleMouseRelease)
 
-map({ "n", "x" }, "<C-q>", mc.toggleCursor, { desc = "Toggle Multicursor" })
+map("Toggle Multicursor", { "n", "x" }, "<C-q>", mc.toggleCursor)
 
 mc.addKeymapLayer(function(layerMap)
   layerMap({ "n", "x" }, "<left>", mc.prevCursor, { desc = "Move to Prev Cursor" })

--- a/plugin/venv-selector.lua
+++ b/plugin/venv-selector.lua
@@ -59,8 +59,9 @@ vim.api.nvim_create_autocmd("FileType", {
         { "<LocalLeader>vr", "<Cmd>VenvSelect<CR>", buffer = bufnr, desc = "Resync PEP 723 Script Deps" },
       })
     else
+      local mappings_map = require("helpers.mappings").map
       local function map(lhs, rhs, desc)
-        vim.keymap.set("n", lhs, rhs, { buffer = bufnr, silent = true, desc = desc })
+        mappings_map(desc, "n", lhs, rhs, { buffer = bufnr, silent = true })
       end
       map("<LocalLeader>vs", "<Cmd>VenvSelect<CR>", "Select Virtualenv")
       map("<LocalLeader>vc", "<Cmd>VenvSelectCached<CR>", "Activate Cached Venv")


### PR DESCRIPTION
## Summary

A new helper `M.map(desc, mode, lhs, rhs, opts?)` landed earlier at [`lua/helpers/mappings.lua`](lua/helpers/mappings.lua) as a thin, behavior-preserving wrapper around `vim.keymap.set`. This PR migrates every hand-written `vim.keymap.set` call in the repo to the new helper so each mapping's intent leads the call site.

## Why

- **Readability:** `desc` is now the required first positional arg, so a mapping's purpose is visible at a glance instead of buried after a multi-line `rhs` callback.
- **Consistency:** enforces a `desc` on every keymap — previously many were unlabeled in which-key / `:verbose map`.

## Key changes

Each commit migrates one file — no behavior changes, just a signature reorder and added descriptions where they were missing.

- `refactor(autocmds)` — `lua/config/autocmds.lua` `close_with_q` mapping
- `refactor(keymaps)` — `lua/config/keymaps.lua` (global keymaps; added descriptions for `q`/`p`/undo break-points/indent helpers/etc.)
- `refactor(lsp)` — `plugin/lsp.lua` (drops the now-redundant local `noremap(desc)` helper)
- `refactor(multicursor)` — `plugin/multicursor.lua` (added descriptions to the three mouse handlers; `layerMap(...)` calls inside `mc.addKeymapLayer` are intentionally untouched — different API)
- `refactor(mini)` — `plugin/mini.lua` (7 buffer-local `MiniFilesBufferCreate` keymaps)
- `refactor(illuminate)` — `plugin/illuminate.lua` (`map_ref` helper)
- `refactor(flash)` — `plugin/flash.lua` (lazy-load stub + its self-replacement)
- `refactor(dial)` — `plugin/dial.lua` (4 `expr = true` mappings)
- `refactor(venv-selector)` — `plugin/venv-selector.lua` (fallback branch when which-key isn't available)

## Decisions / reviewer notes

- **`noremap = true` dropped** everywhere — it's the default in both `vim.keymap.set` and the new helper (`Opts` doesn't accept it).
- **Helper's `Opts` type rejects `desc`** — it's a positional arg only. This is enforced at the call site and surfaces anyone trying to smuggle it through the table.
- **Descriptions added where missing** (not left empty) so every mapping shows up properly in which-key. The added strings lean short and concrete (e.g., `"Unmap q"`, `"No-yank paste"`, `"Multicursor mouse down"`).
- **Not touched:** the `vim.keymap.set` inside `lua/helpers/mappings.lua` itself (that's the helper's implementation); `layerMap(...)` in multicursor (not `vim.keymap.set`); `snacks.toggle(...):map(...)` in illuminate (not `vim.keymap.set`).

## Test notes

- Each file-level migration was verified in isolation via `just check` (selene clean, stylua clean) before being committed here.
- Repo-level `just check` currently surfaces selene errors sourced **only** from the `.claude/worktrees/agent-*` worker-worktree directories still on disk — they're superfluous now that the edits are committed on this branch, and can be cleaned up with `git worktree remove` plus `git branch -D worktree-agent-*`.