### PR TITLE
Add Rust language support

### DIFF
--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -192,6 +192,10 @@
       "rev": "063cc44da1eef8681bbd653b29d3bc961780886a",
       "src": "https://github.com/stevearc/quicker.nvim"
     },
+    "rustaceanvim": {
+      "rev": "824491c58bdba1f6f5e35e64e0ab8b2e2425d6b2",
+      "src": "https://github.com/mrcjkb/rustaceanvim"
+    },
     "scrollEOF.nvim": {
       "rev": "e462b9a07b8166c3e8011f1dcbc6bf68b67cd8d7",
       "src": "https://github.com/Aasim-A/scrollEOF.nvim"

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -30,6 +30,10 @@
       "rev": "086a40dc7ed8242c03be9f47fbcee68699cc2395",
       "src": "https://github.com/stevearc/conform.nvim"
     },
+    "crates.nvim": {
+      "rev": "694357861ec9ebf12475ddcdd04ea45a0923c32d",
+      "src": "https://github.com/saecki/crates.nvim"
+    },
     "cutlass.nvim": {
       "rev": "d01b5c1943050fcda8edf5c89d4419c41a65890e",
       "src": "https://github.com/gbprod/cutlass.nvim"

--- a/plugin/conform.lua
+++ b/plugin/conform.lua
@@ -12,6 +12,7 @@ vim.api.nvim_create_autocmd("BufWritePre", {
       formatters_by_ft = {
         lua = { "stylua" },
         python = { "ruff_format" },
+        rust = { "rustfmt" },
         sh = { "shfmt" },
         yaml = { "yamlfmt" },
       },
@@ -39,6 +40,7 @@ vim.api.nvim_create_user_command("ConformInfo", function()
     formatters_by_ft = {
       lua = { "stylua" },
       python = { "ruff_format" },
+      rust = { "rustfmt" },
       sh = { "shfmt" },
       yaml = { "yamlfmt" },
     },

--- a/plugin/crates.lua
+++ b/plugin/crates.lua
@@ -1,0 +1,16 @@
+-- github.com/saecki/crates.nvim
+-- Inline info (latest version, features, vulnerabilities) in Cargo.toml
+vim.pack.add({ "https://github.com/saecki/crates.nvim" }, { load = false })
+
+-- Cargo.toml is the only file that uses this plugin. Trigger on the first
+-- BufRead/BufNewFile, then re-fire the event for the triggering buffer so
+-- crates.nvim's own just-registered handler attaches to it.
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+  pattern = "Cargo.toml",
+  once = true,
+  callback = function(ev)
+    vim.cmd.packadd("crates.nvim")
+    require("crates").setup()
+    vim.api.nvim_exec_autocmds(ev.event, { buffer = ev.buf, modeline = false })
+  end,
+})

--- a/plugin/lsp/core.lua
+++ b/plugin/lsp/core.lua
@@ -73,6 +73,7 @@ require("mason").setup({
     "lua-language-server",
     "markdownlint-cli2",
     "ruff",
+    "rust-analyzer",
     "selene",
     "shellcheck",
     "shfmt",

--- a/plugin/lsp/rust.lua
+++ b/plugin/lsp/rust.lua
@@ -1,0 +1,27 @@
+-- github.com/mrcjkb/rustaceanvim
+-- rust-analyzer wrapper with extra Rust UX (lazy-loaded on FileType rust)
+vim.pack.add({ "https://github.com/mrcjkb/rustaceanvim" }, { load = false })
+
+-- rustaceanvim is configured via the global vim.g.rustaceanvim, which it
+-- reads when its ftplugin first runs. Set this BEFORE the packadd below.
+vim.g.rustaceanvim = {
+  server = {
+    default_settings = {
+      ["rust-analyzer"] = {
+        check = { command = "clippy" },
+      },
+    },
+  },
+}
+
+-- rustaceanvim ships an ftplugin that wires up rust-analyzer the moment
+-- it loads, so packadd it the first time a Rust buffer appears, then
+-- re-fire FileType so the just-loaded ftplugin runs against this buffer.
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "rust",
+  once = true,
+  callback = function()
+    vim.cmd.packadd("rustaceanvim")
+    vim.api.nvim_exec_autocmds("FileType", { pattern = "rust" })
+  end,
+})


### PR DESCRIPTION
## Summary

Adds first-class Rust support to the Neovim configuration:

- **LSP** via `rustaceanvim` (rust-analyzer wrapper) — lazy-loaded on `FileType rust`
- **Cargo.toml hints** via `crates.nvim` — lazy-loaded on `BufRead Cargo.toml`
- **Formatting** via `rustfmt` through `conform.nvim`
- **Linting** via `clippy` through rust-analyzer's `checkOnSave` (no separate linter)

Also reorganizes `plugin/lsp.lua` → `plugin/lsp/core.lua` so language-specific LSP setup has a natural home (`plugin/lsp/<lang>.lua`). Neovim sources `plugin/**/*.lua` recursively; `core` sorts before `rust`, so the general LSP infra still runs first.

## Key changes

- `plugin/lsp/core.lua` — moved from `plugin/lsp.lua`; adds `"rust-analyzer"` to Mason `ensure_installed`
- `plugin/lsp/rust.lua` — new; configures rustaceanvim with `check = { command = "clippy" }`
- `plugin/crates.lua` — new; sets up crates.nvim and re-fires the triggering event so its own `BufRead` handler attaches to the buffer
- `plugin/conform.lua` — adds `rust = { "rustfmt" }` to both `formatters_by_ft` tables (the on-save callback and the `:ConformInfo` stub)
- `nvim-pack-lock.json` — pins `rustaceanvim` and `crates.nvim`

## Decisions worth flagging

- **Why rustaceanvim instead of plain `vim.lsp.config("rust_analyzer", …)`** — rustaceanvim manages rust-analyzer attachment via its own `FileType rust` ftplugin and provides extra Rust UX (`:RustLsp`, debugging, etc.) without much config. Adding both would conflict, so this PR does **not** add `rust_analyzer` to `vim.lsp.enable()`.
- **Clippy runs once, via the LSP** — set `check.command = "clippy"` in rustaceanvim's `default_settings`. An earlier draft also added `clippy` to `nvim-lint`, but that double-ran clippy and produced spurious `cargo exited 101` errors. Dropped from `nvim-lint`; rust-analyzer handles it on save.
- **`checkOnSave` schema** — modern rust-analyzer expects `checkOnSave: bool` and `check.command: string` (not the older `checkOnSave: { command }` map). Initial draft used the old shape and tripped `LSPrust-analyzer invalid config value`.
- **crates.nvim attach pattern** — naive `require("crates").attach()` blew up under `auto-session` restore (current buffer wasn't the Cargo.toml). Fixed by re-firing the original event with the original buffer (same pattern `plugin/conform.lua` already uses).

## Prerequisites

`rustup` with the default toolchain (provides `cargo`, `rustfmt`, `clippy`). If missing: `rustup component add rustfmt clippy`.

## Verification

- `just check` — clean (selene 0/0, stylua clean, 124/124 tests pass)
- Headless smoke tests against a fresh `cargo new` project:
  - Opening `src/main.rs` → `rust-analyzer` attaches with `check.command = "clippy"`, no error messages
  - Opening `Cargo.toml` → no errors, crates.nvim attaches

## Out of scope

Other Rust-adjacent things intentionally not added: DAP/codelldb integration, custom keymaps for `:RustLsp`, project-specific `rust-analyzer` overrides.