### PR TITLE
Add blank line after treesitter require

### DIFF
--- a/plugin/treesitter.lua
+++ b/plugin/treesitter.lua
@@ -3,6 +3,7 @@
 vim.pack.add({ "https://github.com/nvim-treesitter/nvim-treesitter" })
 
 local ts = require("nvim-treesitter")
+
 -- stylua: ignore start
 local langs = {
   "bash",           "javascript",       "python",


### PR DESCRIPTION
## Summary

Inserts a blank line between `local ts = require("nvim-treesitter")` and the `-- stylua: ignore start` block in [plugin/treesitter.lua](plugin/treesitter.lua) to visually separate the module import from the language list.

## Change

- `plugin/treesitter.lua`: one added blank line; no functional or syntactic change.

## Notes

- Cosmetic only — safe to land independently.