### PR TITLE
Enable helix preset for which-key

### DIFF
--- a/plugin/which-key.lua
+++ b/plugin/which-key.lua
@@ -9,6 +9,8 @@ vim.schedule(function()
   local Snacks = require("snacks")
 
   require("which-key").setup({
+    preset = "helix",
+
     -- stylua: ignore
     spec = {
       -- Top-level Things


### PR DESCRIPTION
## Summary

Switches [which-key.nvim](plugin/which-key.lua)'s popup style to its built-in `helix` preset.

## Change

- `plugin/which-key.lua`: set `preset = "helix"` on `require("which-key").setup({ ... })`.

## Why

- `helix` renders the which-key popup in a compact Helix-editor-style layout — a personal preference over the default look. All existing `spec` mappings are preserved unchanged.

## Notes

- Pure configuration change; no keymap or behavior changes beyond popup visuals.