### PR TITLE
Add taplo as the TOML formatter

### DIFF
--- a/plugin/conform.lua
+++ b/plugin/conform.lua
@@ -15,6 +15,7 @@ vim.api.nvim_create_autocmd("BufWritePre", {
         python = { "ruff_format" },
         rust = { "rustfmt" },
         sh = { "shfmt" },
+        toml = { "taplo" },
         yaml = { "yamlfmt" },
       },
       formatters = {
@@ -48,6 +49,7 @@ vim.api.nvim_create_user_command("ConformInfo", function()
       python = { "ruff_format" },
       rust = { "rustfmt" },
       sh = { "shfmt" },
+      toml = { "taplo" },
       yaml = { "yamlfmt" },
     },
     formatters = {


### PR DESCRIPTION
## Summary

Register the [`taplo`](https://github.com/tamasfe/taplo) CLI as the formatter for TOML files in conform.nvim, so TOML files get auto-formatted on save alongside the other filetypes.

## Changes

- Added `toml = { "taplo" }` to `formatters_by_ft` in [plugin/conform.lua](plugin/conform.lua).
- Added the same entry to the duplicate `formatters_by_ft` table inside the `:ConformInfo` stub command, to keep the lazy-loaded and info-stub configurations in sync.

## Notes

- **No Mason or LSP changes needed.** `taplo` is already in `ensure_installed` and already enabled as an LSP server in `plugin/lsp/core.lua`. Conform ships a built-in `taplo` formatter definition, so no custom `formatters` entry is required.
- `format_on_save.lsp_format = "fallback"` means conform's taplo formatter now takes precedence over the LSP-provided formatter for TOML buffers.

## Verification

- `just check` — 0 lint warnings, stylua clean, 124 tests pass.
- Manual: open a `.toml` file, edit whitespace, `:w` → taplo reformats. `:ConformInfo` lists `taplo` for filetype `toml`.