### PR TITLE
Ignore MemPalace per-project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ data
 .DS_Store
 .claude/settings.local.json
 **/CLAUDE.md
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json


### PR DESCRIPTION
## Summary

Add `mempalace.yaml` and `entities.json` to `.gitignore` so local [MemPalace](https://github.com/) per-project state files aren't accidentally committed.

## Changes

- Appended a `# MemPalace per-project files (issue #185)` section to `.gitignore` with two entries.