### PR TITLE
Focus cursorcolumn on the active window

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -187,3 +187,15 @@ vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
     vim.schedule(edit_watch)
   end,
 })
+
+-- Sets cursorcolumn only in the windows that have focus.
+vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
+  callback = function()
+    vim.wo.cursorcolumn = true
+  end,
+})
+vim.api.nvim_create_autocmd({ "WinLeave" }, {
+  callback = function()
+    vim.wo.cursorcolumn = false
+  end,
+})


### PR DESCRIPTION
## Summary

Limits the `cursorcolumn` highlight to the focused window so inactive splits stay visually quieter.

## Changes

- `WinEnter` / `BufEnter` autocmd — enables `cursorcolumn` when a window gains focus
- `WinLeave` autocmd — disables `cursorcolumn` when a window loses focus

## Scope

- `lua/config/autocmds.lua` only — no other files touched